### PR TITLE
Fixes the Year Value

### DIFF
--- a/src/main/java/com/google/sps/servlets/Post.java
+++ b/src/main/java/com/google/sps/servlets/Post.java
@@ -45,7 +45,6 @@ public class Post {
         organizationName = request.getParameter("organizationName");
         month = Integer.parseInt(request.getParameter("month")) - 1; // Months are indexed at 0.
         day = Integer.parseInt(request.getParameter("day"));
-        year = Integer.parseInt(request.getParameter("year"));
         startHour = Integer.parseInt(request.getParameter("startHour"));
         startMinute = Integer.parseInt(request.getParameter("startMinute"));
         endHour = Integer.parseInt(request.getParameter("endHour"));
@@ -70,6 +69,11 @@ public class Post {
 
         // Translate the start time into minutes to allow for sorting.
         timeSort = startHour * 60 + startMinute;
+
+        // Set the year. Right now time zone is set to "America/Los_Angeles".
+        Calendar nowTime = Calendar.getInstance(TimeZone.getTimeZone("America/Los_Angeles"));
+        year = nowTime.get(Calendar.YEAR);
+
     }
 
     /* Translate the entities from the Datastore query to Post objects and return in an array. */
@@ -87,7 +91,7 @@ public class Post {
             Calendar postTime = Calendar.getInstance(TimeZone.getTimeZone("America/Los_Angeles"));
             int postMonth = Integer.parseInt(entity.getProperty("month").toString());
             int postDay = Integer.parseInt(entity.getProperty("day").toString());
-            int postYear = 2000 + Integer.parseInt(entity.getProperty("year").toString());
+            int postYear = Integer.parseInt(entity.getProperty("year").toString());
             int postHour = Integer.parseInt(entity.getProperty("endHour").toString());
             int postMinute = Integer.parseInt(entity.getProperty("endMinute").toString());
             postTime.set(postYear, postMonth, postDay, postHour, postMinute);

--- a/src/main/webapp/assets/css/feedStyle.css
+++ b/src/main/webapp/assets/css/feedStyle.css
@@ -158,6 +158,10 @@ select {
   margin-right: 20px;
 }
 
+#modal-day {
+  margin-right: 20px;
+}
+
 .modal-span {
   white-space: nowrap;
 }

--- a/src/main/webapp/find-events.html
+++ b/src/main/webapp/find-events.html
@@ -81,8 +81,6 @@
             <input type="number" id="modal-month" name="month" placeholder="mm" min="1" max="12" step="1">
             <p id="modal-slash">/</p>
             <input type="number" id="modal-day" name="day" placeholder="dd" min="1" max="31" step="1">
-            <p id="modal-slash">/</p>
-            <input type="number" id="modal-year" name="year" placeholder="yy" min="20" max="30" step="1">
           </span>
 
           <span class="modal-span">


### PR DESCRIPTION
Small PR: eliminates the option for users to input a year, and instead gets the year from the calendar. 
Fixes issue #54 where the year for the posts was off by 100 years.

New modal:
![Screenshot 2020-08-07 at 2 19 34 PM](https://user-images.githubusercontent.com/48428336/89689360-10c33780-d8b9-11ea-923a-ebac1dc36846.png)

New storage of year:
![Screenshot 2020-08-07 at 2 12 31 PM](https://user-images.githubusercontent.com/48428336/89689312-f2f5d280-d8b8-11ea-97cd-dbf1d395d567.png)

