### PR TITLE
Add Manual Validation for Email Form

### DIFF
--- a/src/main/webapp/assets/css/signUpStyle.css
+++ b/src/main/webapp/assets/css/signUpStyle.css
@@ -105,21 +105,19 @@ button:hover {
   border: none;
 }
 
-#form-submitted {
-  background: white;
+#subscribe-form-submitted,
+#unsubscribe-form-submitted {
+  background: var(--tan);
   border-radius: 15px;
   box-shadow: 0 1px 10px grey, 0 -1px 10px grey;
+  color: #fff;
   display: none;
   left: 25%;
   overflow: auto;
-  padding: 30px;
+  padding: 2rem;
   position: fixed;
   top: 50%;
   transform: translate(0, -50%);
   width: 50%;
   z-index: 1;
-}
-
-#form-submitted-title {
-  margin-left: 12px;
 }

--- a/src/main/webapp/assets/css/signUpStyle.css
+++ b/src/main/webapp/assets/css/signUpStyle.css
@@ -89,7 +89,7 @@ input[type=radio] {
   text-align: left;
 }
 
-input[type=submit] {
+#form-submit {
   background-color: var(--light-maroon);
   border: none;
   border-radius: 4px;
@@ -100,7 +100,26 @@ input[type=submit] {
   width: 30%;
 }
 
-input[type=submit]:hover {
+button:hover {
   background-color: var(--dark-maroon);
   border: none;
+}
+
+#form-submitted {
+  background: white;
+  border-radius: 15px;
+  box-shadow: 0 1px 10px grey, 0 -1px 10px grey;
+  display: none;
+  left: 25%;
+  overflow: auto;
+  padding: 30px;
+  position: fixed;
+  top: 50%;
+  transform: translate(0, -50%);
+  width: 50%;
+  z-index: 1;
+}
+
+#form-submitted-title {
+  margin-left: 12px;
 }

--- a/src/main/webapp/assets/css/signUpStyle.css
+++ b/src/main/webapp/assets/css/signUpStyle.css
@@ -33,7 +33,7 @@
 }
 
 .content {
-  padding: 12%;
+  padding: 10%;
   padding-top: 2%;
   text-align: center;
 }

--- a/src/main/webapp/assets/css/signUpStyle.css
+++ b/src/main/webapp/assets/css/signUpStyle.css
@@ -107,10 +107,10 @@ button:hover {
 
 #subscribe-form-submitted,
 #unsubscribe-form-submitted {
-  background: var(--tan);
+  background: #fff;
   border-radius: 15px;
   box-shadow: 0 1px 10px grey, 0 -1px 10px grey;
-  color: #fff;
+  color: #000;
   display: none;
   left: 25%;
   overflow: auto;

--- a/src/main/webapp/assets/css/signUpStyle.css
+++ b/src/main/webapp/assets/css/signUpStyle.css
@@ -105,8 +105,7 @@ button:hover {
   border: none;
 }
 
-#subscribe-form-submitted,
-#unsubscribe-form-submitted {
+#form-submitted {
   background: #fff;
   border-radius: 15px;
   box-shadow: 0 1px 10px grey, 0 -1px 10px grey;

--- a/src/main/webapp/assets/js/signUpScript.js
+++ b/src/main/webapp/assets/js/signUpScript.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // This file provides the JavaScript induced on the sign up page (sign-up.html) with
-// form validation to impose strict restrictions on user input (from feedScript.js) and 
+// form validation to impose strict restrictions on user input (from feedScript.js) and
 // college dropdown support (from indexScript.js).
 
 //
@@ -86,16 +86,20 @@ async function submitForm() {
   submitFormButton.disabled = true;
 
   if (validateForm()) {
-    emailForm.action = "/user";
+    emailForm.action = '/user';
 
     // Based on user subscribing or unsubscribing, show confirmation that form
     // was submitted.
-    if(document.getElementById("subscribe").checked) {
+    if (document.getElementById('subscribe').checked) {
       subscribeFormSubmitted.style.display = 'block';
     } else {
       unsubscribeFormSubmitted.style.display = 'block';
     }
-    emailForm.submit();
+
+    // Waits for 4000 ms so user can read confirmation and submits the form.
+    setTimeout(function() {
+      emailForm.submit();
+    }, 4000);
   } else {
     submitFormButton.disabled = false;
   }
@@ -192,7 +196,8 @@ function validateFormCollege(invalidIds, errorMessages, formElements) {
     selectedCollege.value = collegeId;
   } else {
     invalidIds.push(formElements.namedItem('colleges').id);
-    const errorMessage = 'we currently do not support that college; please pick college from given list';
+    const errorMessage = 'we currently do not support that college; ' +
+     'please pick college from given list';
     errorMessages.push(errorMessage);
   }
 }

--- a/src/main/webapp/assets/js/signUpScript.js
+++ b/src/main/webapp/assets/js/signUpScript.js
@@ -31,10 +31,7 @@ document.addEventListener('DOMContentLoaded', onLoad);
 let emailForm;
 
 /** @type {HTMLElement} */
-let subscribeFormSubmitted;
-
-/** @type {HTMLElement} */
-let unsubscribeFormSubmitted;
+let formSubmitted;
 
 /** @type {HTMLElement} */
 let submitFormButton;
@@ -72,14 +69,12 @@ async function onLoad() {
   // When users submit the form, initiate form validation.
   emailForm = document.getElementById('email-form');
   submitFormButton = document.getElementById('form-submit');
-  subscribeFormSubmitted = document.getElementById('subscribe-form-submitted');
-  unsubscribeFormSubmitted = document.getElementById('unsubscribe-form-submitted');
+  formSubmitted = document.getElementById('form-submitted');
   submitFormButton.addEventListener('click', submitForm);
 }
 
 /**
  * On click of the submit button, validate form data and send data to the servlet.
- * @return {void}
  */
 async function submitForm() {
   // Disable multiple submissions.
@@ -89,17 +84,14 @@ async function submitForm() {
     emailForm.action = '/user';
 
     // Based on user subscribing or unsubscribing, show confirmation that form
-    // was submitted.
-    if (document.getElementById('subscribe').checked) {
-      subscribeFormSubmitted.style.display = 'block';
-    } else {
-      unsubscribeFormSubmitted.style.display = 'block';
-    }
-
-    // Waits for 4000 ms so user can read confirmation and submits the form.
-    setTimeout(function() {
-      emailForm.submit();
-    }, 4000);
+    // was submitted and submit the form.
+    const submittedConfirmationMessage = document.getElementById('subscribe').checked ?
+      'thanks for joining the noms fam! check your email for a subscription confirmation!' :
+      'hope you have enjoyed your time with noms!';
+    
+    document.getElementById('confirmation-text').innerHTML = submittedConfirmationMessage;
+    formSubmitted.style.display = 'block';
+    emailForm.submit();
   } else {
     submitFormButton.disabled = false;
   }
@@ -107,8 +99,7 @@ async function submitForm() {
 
 /**
  * Goes through the form elements and marks the invalid inputs.
- * Returns whether all the inputs are valid.
- * @return {boolean}
+ * @return {boolean} whether all the inputs are valid
  */
 function validateForm() {
   const invalidIds = [];
@@ -127,10 +118,9 @@ function validateForm() {
 
 /**
  * Checks if the email is valid.
- * @param {array} invalidIds
- * @param {array} errorMessages
- * @param {array} formElements
- * @return {void}
+ * @param {Array<string>} invalidIds - ids of invalid inputs
+ * @param {Array<string>} errorMessages - error messages of invalid inputs
+ * @param {Array<HTMLElement>} formElements - email form input elements
  */
 function validateFormEmail(invalidIds, errorMessages, formElements) {
   const email = formElements.namedItem('email').value;
@@ -143,16 +133,15 @@ function validateFormEmail(invalidIds, errorMessages, formElements) {
 
 /**
  * Checks if at least one radio button has been checked.
- * @param {array} invalidIds
- * @param {array} errorMessages
- * @param {array} formElements
- * @return {void}
+ * @param {Array<string>} invalidIds - ids of invalid inputs
+ * @param {Array<string>} errorMessages - error messages of invalid inputs
+ * @param {Array<HTMLElement>} formElements - email form input elements
  */
 function validateFormRadioButtons(invalidIds, errorMessages, formElements) {
-  const subscribe = formElements.namedItem('email-notif')[0].checked;
-  const unsubscribe = formElements.namedItem('email-notif')[1].checked;
+  const subscribeRadioButton = formElements.namedItem('email-notif')[0].checked;
+  const unsubscribeRadioButton = formElements.namedItem('email-notif')[1].checked;
 
-  if (!subscribe && !unsubscribe ) {
+  if (!subscribeRadioButton && !unsubscribeRadioButton) {
     invalidIds.push('subscribe');
     errorMessages.push('must pick to subscribe or unsubscribe');
   }
@@ -160,10 +149,9 @@ function validateFormRadioButtons(invalidIds, errorMessages, formElements) {
 
 /**
  * Check if form text elements have been filled out completely.
- * @param {array} invalidIds
- * @param {array} errorMessages
- * @param {array} formElements
- * @return {void}
+ * @param {Array<string>} invalidIds - ids of invalid inputs
+ * @param {Array<string>} errorMessages - error messages of invalid inputs
+ * @param {Array<HTMLElement>} formElements - email form input elements
  */
 function validateFormText(invalidIds, errorMessages, formElements) {
   // Checks if any text elements are blank.
@@ -180,10 +168,9 @@ function validateFormText(invalidIds, errorMessages, formElements) {
 
 /**
  * Check if valid college.
- * @param {array} invalidIds
- * @param {array} errorMessages
- * @param {array} formElements
- * @return {void}
+ * @param {Array<string>} invalidIds - ids of invalid inputs
+ * @param {Array<string>} errorMessages - error messages of invalid inputs
+ * @param {Array<HTMLElement>} formElements - email form input elements
  */
 function validateFormCollege(invalidIds, errorMessages, formElements) {
   const collegeName = document.getElementById('colleges-input-form').value;
@@ -204,10 +191,9 @@ function validateFormCollege(invalidIds, errorMessages, formElements) {
 /**
  * Highlight invalid inputs with a red background and
  * adds error messages.
- * @param {array} invalidIds
- * @param {array} errorMessages
- * @param {array} formElements
- * @return {void}
+ * @param {Array<string>} invalidIds - ids of invalid inputs
+ * @param {Array<string>} errorMessages - error messages of invalid inputs
+ * @param {Array<HTMLElement>} formElements - email form input elements
  */
 function markInvalidInputs(invalidIds, errorMessages, formElements) {
   resetMarks(formElements);
@@ -233,8 +219,7 @@ function markInvalidInputs(invalidIds, errorMessages, formElements) {
  * Goes through the elements and encodes common HTML enities.
  * By using these codes, ensures that the user's inputs are seen as data, not code.
  * This is a measure against a malicious users trying to changing site data.
- * @param {array} formElements
- * @return {void}
+ * @param {Array<HTMLElement>} formElements - email form input elements
  */
 function disableInjection(formElements) {
   for (let i = 0; i < formElements.length - 1; i++) {
@@ -248,8 +233,7 @@ function disableInjection(formElements) {
 
 /**
  * Resets all the input backgrounds and gets rid of previous error text.
- * @param {array} formElements
- * @return {void}
+ * @param {Array<HTMLElement>} formElements - email form input elements
  */
 function resetMarks(formElements) {
   for (let i = 0; i < formElements.length - 1; i++) {

--- a/src/main/webapp/assets/js/signUpScript.js
+++ b/src/main/webapp/assets/js/signUpScript.js
@@ -134,7 +134,7 @@ function validateForm() {
  */
 function validateFormEmail(invalidIds, errorMessages, formElements) {
   const email = formElements.namedItem('email').value;
-  var emailPattern = /^[a-zA-Z0-9._-]+@google.com$/;
+  const emailPattern = /^[a-zA-Z0-9._-]+@google.com$/;
   if (!emailPattern.test(email)) {
     invalidIds.push('email');
     errorMessages.push('email must follow @google.com');
@@ -166,7 +166,6 @@ function validateFormRadioButtons(invalidIds, errorMessages, formElements) {
  * @return {void}
  */
 function validateFormText(invalidIds, errorMessages, formElements) {
-
   // Checks if any text elements are blank.
   for (let i = 0; i < formElements.length; i++) {
     if (formElements[i].type === 'text' || formElements[i].type === 'email') {
@@ -203,7 +202,7 @@ function validateFormCollege(invalidIds, errorMessages, formElements) {
 }
 
 /**
- * Highlight invalid inputs with a red background and 
+ * Highlight invalid inputs with a red background and
  * adds error messages.
  * @param {array} invalidIds
  * @param {array} errorMessages

--- a/src/main/webapp/assets/js/signUpScript.js
+++ b/src/main/webapp/assets/js/signUpScript.js
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file provides the JavaScript induced on the sign up page (sign-up.html) which is
-// a replica from the main page (index.html) without additional functionality to load posts.
+// This file provides the JavaScript induced on the sign up page (sign-up.html) with
+// form validation to impose strict restrictions on user input (from feedScript.js) and 
+// college dropdown support (from indexScript.js).
 
 //
 // Event listener registration
@@ -21,6 +22,22 @@
 
 // Hooks the onLoad function to the DOMContentLoaded event.
 document.addEventListener('DOMContentLoaded', onLoad);
+
+//
+// Elements
+//
+
+/** @type {HTMLElement} */
+let formSubmitted;
+
+/** @type {HTMLElement} */
+let formSubmittedTitle;
+
+/** @type {HTMLElement} */
+let submitFormButton;
+
+/** @type {HTMLElement} */
+let emailForm;
 
 //
 // Functions
@@ -54,6 +71,22 @@ async function onLoad() {
 
   // When users select an option from the dropdown, set the college id.
   document.getElementById('colleges-input-form').addEventListener('change', setCollegeID);
+
+  submitFormButton = document.getElementById('form-submit');
+  emailForm = document.getElementById('email-form');
+  formSubmitted = document.getElementById('form-submitted');
+  formSubmittedTitle = document.getElementById('form-submitted-title');
+  submitFormButton.addEventListener('click', submitModal);
+}
+
+/**
+ * Checks if the given input is blank.
+ * @param {String} input
+ * @return {void}
+ */
+function isBlank(input) {
+  const trimmed = input.trim();
+  return !trimmed;
 }
 
 /**
@@ -70,5 +103,168 @@ function setCollegeID() {
     const collegeId = option.dataset.value;
     const selectedCollege = document.getElementById('cID');
     selectedCollege.value = collegeId;
+  }
+}
+
+/**
+ * On click of the submit button, sends modal data to the servlet.
+ * @return {void}
+ */
+async function submitModal() {
+  // Disable multiple submissions.
+  submitFormButton.disabled = true;
+
+  if (validateModal()) {
+    checkLocationAndSubmit();
+  } else {
+    submitFormButton.disabled = false;
+  }
+}
+
+/**
+ * Checks if the month and day are a valid date.
+ * @param {array} invalidIds
+ * @param {array} errorMessages
+ * @param {array} formElements
+ * @return {void}
+ */
+function validateModalDate(invalidIds, errorMessages, formElements) {
+  const month = formElements.namedItem('modal-month').value;
+  const day = formElements.namedItem('modal-day').value;
+  const monthDayLengths = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month > 12 || month < 1) {
+    invalidIds.push('modal-month');
+    errorMessages.push('month must be between 1 and 12');
+  }
+  if (day < 1 || day > monthDayLengths[month - 1] || isBlank(day)) {
+    invalidIds.push('modal-day');
+    errorMessages.push('invalid date');
+  }
+}
+
+
+/**
+ * Goes through the form elements and marks the invalid inputs.
+ * Returns whether all the inputs are valid.
+ * @return {boolean}
+ */
+function validateModal() {
+  const invalidIds = [];
+  const errorMessages = [];
+  const formElements = emailForm.elements;
+
+  disableInjection(formElements);
+  validateModalText(invalidIds, errorMessages, formElements);
+  markInvalidInputs(invalidIds, errorMessages, formElements);
+
+  return (invalidIds.length === 0);
+}
+
+/**
+ * Goes through the elements and encodes common HTML enities.
+ * By using these codes, ensures that the user's inputs are seen as data, not code.
+ * This is a measure against a malicious users trying to changing site data.
+ * @param {array} formElements
+ * @return {void}
+ */
+function disableInjection(formElements) {
+  for (let i = 0; i < formElements.length - 1; i++) {
+    let elementValue = formElements[i].value;
+    elementValue = elementValue.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    elementValue = elementValue.replace(/&/g, '&amp;');
+    elementValue = elementValue.replace(/"/g, '&quot;');
+    elementValue = elementValue.replace(/'/g, '&#x27;');
+  }
+}
+
+/**
+ * Goes through the form elements. If it is a text input, adds an error if it is blank.
+ * @param {array} invalidIds
+ * @param {array} errorMessages
+ * @param {array} formElements
+ * @return {void}
+ */
+function validateModalText(invalidIds, errorMessages, formElements) {
+  for (let i = 0; i < formElements.length; i++) {
+    if (formElements[i].type === 'text' || formElements[i].type === 'textarea') {
+      if (isBlank(formElements[i].value)) {
+        invalidIds.push(formElements[i].id);
+        const errorMessage = formElements[i].placeholder + ' is blank';
+        errorMessages.push(errorMessage);
+      }
+    }
+  }
+}
+
+/**
+ * Checks if the inputted address is valid.
+ * Submits if address is verified.
+ * @return {void}
+ */
+async function checkLocationAndSubmit() {
+
+  url = `/user`;
+  emailForm.action = url;
+
+  // Hides form modal, shows submit message and focuses on it.
+  modalCard.style.display = 'none';
+  formSubmitted.style.display = 'block';
+  // Closes the submit modal after 2000 ms, and submits the form.
+  setTimeout(function() {
+    closeSubmit();
+    emailForm.submit();
+  }, 2000);
+}
+
+/**
+ * Closes the submit modal.
+ * @return {void}
+ */
+function closeSubmit() {
+  formSubmitted.style.display = 'none';
+}
+
+/**
+ * Goes through the invalid inputs and colors them red.
+ * Adds error messages.
+ * @param {array} invalidIds
+ * @param {array} errorMessages
+ * @param {array} formElements
+ * @return {void}
+ */
+function markInvalidInputs(invalidIds, errorMessages, formElements) {
+  resetMarks(formElements);
+  invalidIds.forEach((id) => {
+    const elt = formElements.namedItem(id);
+    if (elt) {
+      elt.style.background = '#ff999966';
+    }
+  });
+  if (errorMessages.length > 0) {
+    const modalError = document.createElement('div');
+    modalError.setAttribute('id', 'modal-input-error');
+    modalError.setAttribute('tabindex', '0');
+    modalError.innerHTML += '<ul>';
+    errorMessages.forEach((message) => {
+      modalError.innerHTML += '<li>' + message + '</li>';
+    });
+    modalError.innerHTML += '</ul>';
+    emailForm.insertBefore(modalError, submitFormButton);
+  }
+}
+
+/**
+ * Resets all the input backgrounds to modal grey and gets rid of previous error text.
+ * @param {array} formElements
+ * @return {void}
+ */
+function resetMarks(formElements) {
+  for (let i = 0; i < formElements.length - 1; i++) {
+    const element = formElements[i];
+    element.style.background = '#1b18181a';
+  }
+  const modalError = document.getElementById('modal-input-error');
+  if (modalError) {
+    emailForm.removeChild(modalError);
   }
 }

--- a/src/main/webapp/assets/js/signUpScript.js
+++ b/src/main/webapp/assets/js/signUpScript.js
@@ -88,7 +88,6 @@ async function submitForm() {
     const submittedConfirmationMessage = document.getElementById('subscribe').checked ?
       'thanks for joining the noms fam! check your email for a subscription confirmation!' :
       'hope you have enjoyed your time with noms!';
-    
     document.getElementById('confirmation-text').innerHTML = submittedConfirmationMessage;
     formSubmitted.style.display = 'block';
     emailForm.submit();

--- a/src/main/webapp/sign-up.html
+++ b/src/main/webapp/sign-up.html
@@ -61,13 +61,9 @@
             </div>
             <button id="form-submit" type="button">submit</button>
           </form>
-          <div id="subscribe-form-submitted">
+          <div id="form-submitted">
             <h1>form has been submitted!</h1>
-            <p>thanks for joining the noms fam! check your email for a subscription confirmation!</p>
-          </div>
-          <div id="unsubscribe-form-submitted">
-            <h1>form has been submitted!</h1>
-            <p>hope you have enjoyed your time with noms!</p>
+            <p id="confirmation-text"></p>
           </div>
         </div>
       </div>

--- a/src/main/webapp/sign-up.html
+++ b/src/main/webapp/sign-up.html
@@ -40,12 +40,12 @@
           <h2>get notified with emails</h2>
           <form id="email-form" method="post" autocomplete="off">
             <label class="input-name">name</label>
-            <input type="text" name="name" maxlength = "30" required>
+            <input type="text" name="name" id="name" maxlength="50" required>
             <label class="input-name" for="email">email</label>
-            <input type="email" name="email" maxlength = "30" pattern=".+@google.com" title="Must be @google.com." required>
+            <input type="email" name="email" id="email" maxlength = "50" pattern=".+@google.com" title="Must be @google.com." required>
             <label class="input-name">college</label>
             <div class="selectdiv">
-              <input type="text" list="colleges" id="colleges-input-form" required>
+              <input type="text" list="colleges" name="colleges" id="colleges-input-form" required>
               <datalist name="colleges" id="colleges"></datalist>
             </div>
             <input type="hidden" id="cID" name="cID">
@@ -63,7 +63,8 @@
           </form>
         </div>
         <div aria-label="form submitted" id="form-submitted">
-          <h1 id="form-submitted-title"> Form has been submitted! </h1>
+          <h1 id="form-submitted-title">form has been submitted!</h1>
+          <p id="form-submitted-text">thanks for joining the noms fam! check your email for a subscription confirmation!</p>
         </div>
       </div>
     </div>

--- a/src/main/webapp/sign-up.html
+++ b/src/main/webapp/sign-up.html
@@ -40,9 +40,9 @@
           <h2>get notified with emails</h2>
           <form id="email-form" method="post" autocomplete="off">
             <label class="input-name">name</label>
-            <input type="text" name="name" id="name" maxlength="50" required>
+            <input type="text" name="name" id="name" maxlength="35" required>
             <label class="input-name" for="email">email</label>
-            <input type="email" name="email" id="email" maxlength = "50" pattern=".+@google.com" title="Must be @google.com." required>
+            <input type="email" name="email" id="email" maxlength = "35" pattern=".+@google.com" title="Must be @google.com." required>
             <label class="input-name">college</label>
             <div class="selectdiv">
               <input type="text" list="colleges" name="colleges" id="colleges-input-form" required>
@@ -61,10 +61,14 @@
             </div>
             <button id="form-submit" type="button">submit</button>
           </form>
-        </div>
-        <div aria-label="form submitted" id="form-submitted">
-          <h1 id="form-submitted-title">form has been submitted!</h1>
-          <p id="form-submitted-text">thanks for joining the noms fam! check your email for a subscription confirmation!</p>
+          <div id="subscribe-form-submitted">
+            <h1>form has been submitted!</h1>
+            <p>thanks for joining the noms fam! check your email for a subscription confirmation!</p>
+          </div>
+          <div id="unsubscribe-form-submitted">
+            <h1>form has been submitted!</h1>
+            <p>hope you have enjoyed your time with noms!</p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/main/webapp/sign-up.html
+++ b/src/main/webapp/sign-up.html
@@ -38,7 +38,7 @@
         <div class="content">
           <!-- email notification form -->
           <h2>get notified with emails</h2>
-          <form action="/user" method="POST" autocomplete="off">
+          <form id="email-form" method="post" autocomplete="off">
             <label class="input-name">name</label>
             <input type="text" name="name" maxlength = "30" required>
             <label class="input-name" for="email">email</label>
@@ -59,8 +59,11 @@
                 <label for="unsubscribe">unsubscribe</label>
               </div>
             </div>
-            <input type="submit" value="submit">
+            <button id="form-submit" type="button">submit</button>
           </form>
+        </div>
+        <div aria-label="form submitted" id="form-submitted">
+          <h1 id="form-submitted-title"> Form has been submitted! </h1>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Manual Form Validation

With our previous email notifications form, clicking the submit button will trigger with or without the college exiting in the list because the submit aspect is attached to the HTML form that triggers a POST request when the form is submitted. Therefore, I need to take out the POST from the HTML and trigger the submit on the JavaScript side after it checks for the validness of the college. With that in mind, the `<input type="submit">` was removed and will no longer bring up helpful validation messages to the user so I had to create manual validation for the form.

**Make Users Pick Our Supported Colleges** 
Resolves #81.
![image](https://user-images.githubusercontent.com/20546538/91235933-7ef65f80-e6eb-11ea-80f7-2702ed4cb4aa.png)

**Add 'submitted' indicator to subscribing/unsubscribing**
To confirm with users that we've received their form, I included two different boxes for users who are subscribing or unsubscribing. 

Resolves #87. 
![image](https://user-images.githubusercontent.com/20546538/91236035-c7158200-e6eb-11ea-8861-c0e6f1ec7aeb.png)
![image](https://user-images.githubusercontent.com/20546538/91236100-e90f0480-e6eb-11ea-8ad8-f182bc532491.png)




