### PR TITLE
Changes Setup of Datastore

### DIFF
--- a/src/main/java/com/google/sps/data/Post.java
+++ b/src/main/java/com/google/sps/data/Post.java
@@ -47,7 +47,7 @@ public class Post {
   public boolean valid = true; // If false, the post shouldn't be saved - it might have malicious data.
 
   /* Fill in the important Post details from the POST request. */
-  public void requestToPost(HttpServletRequest request, String collegeId) {
+  public void requestToPost(HttpServletRequest request) {
     String orgNameUnparsed = request.getParameter("organizationName");
     String monthUnparsed = request.getParameter("month");
     String dayUnparsed = request.getParameter("day");
@@ -61,6 +61,7 @@ public class Post {
     String numberOfPeopleItFeedsUnparsed = request.getParameter("numberOfPeopleItFeeds");
     String typeOfFoodUnparsed = request.getParameter("typeOfFood");
     String descriptionUnparsed = request.getParameter("description");
+    String collegeIdUnparsed = request.getParameter("collegeId");
 
     // Perform input validation before we attempt to parse the inputs, as things like integers
     // might be invalid and would cause parseInt() to throw an exception.
@@ -96,7 +97,7 @@ public class Post {
     numberOfPeopleItFeeds = Integer.parseInt(numberOfPeopleItFeedsUnparsed);
     typeOfFood = typeOfFoodUnparsed;
     description = descriptionUnparsed;
-    this.collegeId = collegeId;
+    collegeId = collegeIdUnparsed;
 
     // Adjust the start and end hour based on whether the hour is AM or PM.
     startHour = startHour % 12;
@@ -184,13 +185,13 @@ public class Post {
     typeOfFood = (String) entity.getProperty("typeOfFood");
     description = (String) entity.getProperty("description");
     timeSort = Integer.parseInt(entity.getProperty("timeSort").toString());
-    collegeId = (String) entity.getKind();
+    collegeId = (String) entity.getProperty("collegeId");
     postId = entity.getKey().toString();
   }
 
   /* Creates a new entity with the college ID and the Post information. Sets all the properties. */
-  public Entity postToEntity() {
-    Entity newPost = new Entity(collegeId);
+  public Entity postToEntity(String entityKind) {
+    Entity newPost = new Entity(entityKind);
 
     newPost.setProperty("organizationName", organizationName);
 
@@ -212,6 +213,7 @@ public class Post {
     newPost.setProperty("description", description);
 
     newPost.setProperty("timeSort", timeSort);
+    newPost.setProperty("collegeId", collegeId);
 
     return newPost;
   }

--- a/src/main/java/com/google/sps/data/Post.java
+++ b/src/main/java/com/google/sps/data/Post.java
@@ -78,7 +78,8 @@ public class Post {
         !InputPattern.POSITIVE_INTEGER.matcher(numberOfPeopleItFeedsUnparsed).matches() ||
         !InputPattern.TEXT.matcher(typeOfFoodUnparsed).matches() || typeOfFoodUnparsed.length() > 25 ||
         !InputPattern.TEXT.matcher(descriptionUnparsed).matches() || descriptionUnparsed.length() > 500 ||
-        descriptionUnparsed.length() < 15) {
+        descriptionUnparsed.length() < 15 ||
+        !InputPattern.TEXT.matcher(collegeIdUnparsed).matches() || collegeIdUnparsed.length() > 6) {
       valid = false;
       return;
     }

--- a/src/main/java/com/google/sps/servlets/PostDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/PostDataServlet.java
@@ -57,7 +57,7 @@ public class PostDataServlet extends HttpServlet {
 
     // Queries Datastore with the college ID and receives posts such that the soonest events are shown first.
     Filter collegeIdFilter = new FilterPredicate("collegeId", FilterOperator.EQUAL, collegeId);
-    Query query = new Query(entityKind).addSort("timeSort", SortDirection.ASCENDING).setFilter(collegeIdFilter);
+    Query query = new Query(entityKind).setFilter(collegeIdFilter).addSort("timeSort", SortDirection.ASCENDING);
     PreparedQuery results = datastore.prepare(query);
     ArrayList<Post> posts = Post.queryToPosts(results, datastore);
 

--- a/src/main/java/com/google/sps/servlets/PostDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/PostDataServlet.java
@@ -42,7 +42,7 @@ import javax.servlet.http.HttpServletResponse;
 public class PostDataServlet extends HttpServlet {
   
   public static final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  String entityKind = "College";
+  public static final String ENTITY_KIND = "Post";
 
   /* Convert an ArrayList of Post objects to JSON. */
   private String listToJson(ArrayList<Post> alist) {
@@ -57,7 +57,7 @@ public class PostDataServlet extends HttpServlet {
 
     // Queries Datastore with the college ID and receives posts such that the soonest events are shown first.
     Filter collegeIdFilter = new FilterPredicate("collegeId", FilterOperator.EQUAL, collegeId);
-    Query query = new Query(entityKind).setFilter(collegeIdFilter).addSort("timeSort", SortDirection.ASCENDING);
+    Query query = new Query(ENTITY_KIND).setFilter(collegeIdFilter).addSort("timeSort", SortDirection.ASCENDING);
     PreparedQuery results = datastore.prepare(query);
     ArrayList<Post> posts = Post.queryToPosts(results, datastore);
 
@@ -78,7 +78,7 @@ public class PostDataServlet extends HttpServlet {
     newPost.requestToPost(request);
 
     if (newPost.valid) {
-      Entity newPostEntity = newPost.postToEntity(entityKind);
+      Entity newPostEntity = newPost.postToEntity(ENTITY_KIND);
       datastore.put(newPostEntity);
 
       GmailConfiguration.notifyUsers(collegeId, newPost);

--- a/src/main/java/com/google/sps/servlets/PostDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/PostDataServlet.java
@@ -42,6 +42,7 @@ import javax.servlet.http.HttpServletResponse;
 public class PostDataServlet extends HttpServlet {
   
   public static final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+  String entityKind = "College";
 
   /* Convert an ArrayList of Post objects to JSON. */
   private String listToJson(ArrayList<Post> alist) {
@@ -55,7 +56,8 @@ public class PostDataServlet extends HttpServlet {
     String collegeId = request.getParameter("collegeId");
 
     // Queries Datastore with the college ID and receives posts such that the soonest events are shown first.
-    Query query = new Query(collegeId).addSort("timeSort", SortDirection.ASCENDING);
+    Filter collegeIdFilter = new FilterPredicate("collegeId", FilterOperator.EQUAL, collegeId);
+    Query query = new Query(entityKind).addSort("timeSort", SortDirection.ASCENDING).setFilter(collegeIdFilter);
     PreparedQuery results = datastore.prepare(query);
     ArrayList<Post> posts = Post.queryToPosts(results, datastore);
 
@@ -69,13 +71,14 @@ public class PostDataServlet extends HttpServlet {
    * stores the post as entity in Datastore.
    */
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException { 
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String collegeId = request.getParameter("collegeId");
+
     Post newPost = new Post();
-    newPost.requestToPost(request, collegeId);
+    newPost.requestToPost(request);
 
     if (newPost.valid) {
-      Entity newPostEntity = newPost.postToEntity();
+      Entity newPostEntity = newPost.postToEntity(entityKind);
       datastore.put(newPostEntity);
 
       GmailConfiguration.notifyUsers(collegeId, newPost);

--- a/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <datastore-indexes autoGenerate="true">
-  <datastore-index kind="College" ancestor="false" source="manual">
+  <datastore-index kind="Post" ancestor="false" source="manual">
     <property name="collegeId" direction="asc"/>
     <property name="timeSort" direction="asc"/>
   </datastore-index>

--- a/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<datastore-indexes autoGenerate="true">
+  <datastore-index kind="College" ancestor="false" source="manual">
+    <property name="collegeId" direction="asc"/>
+    <property name="timeSort" direction="asc"/>
+  </datastore-index>
+</datastore-indexes>

--- a/src/test/java/com/google/sps/data/PostTest.java
+++ b/src/test/java/com/google/sps/data/PostTest.java
@@ -34,10 +34,11 @@ public final class PostTest {
     when(request.getParameter("numberOfPeopleItFeeds")).thenReturn(Integer.toString(numberOfPeopleItFeeds));
     when(request.getParameter("typeOfFood")).thenReturn(typeOfFood);
     when(request.getParameter("description")).thenReturn(description);
+    when(request.getParameter("collegeId")).thenReturn(collegeId);
 
     // Run requestToPost() on the Mock HTTP Request.
     Post testPost = new Post();
-    testPost.requestToPost(request, collegeId);
+    testPost.requestToPost(request);
 
     // Check if requestToPost() delivered expected results.
     Assert.assertEquals(testPost.getOrganizationName(), organizationName);
@@ -50,6 +51,7 @@ public final class PostTest {
     Assert.assertEquals(testPost.getNumberOfPeopleItFeeds(), numberOfPeopleItFeeds);
     Assert.assertEquals(testPost.getTypeOfFood(), typeOfFood);
     Assert.assertEquals(testPost.getDescription(), description);
+    Assert.assertEquals(testPost.getCollegeId(), collegeId);
 
     return testPost;
   }
@@ -78,10 +80,11 @@ public final class PostTest {
     when(request.getParameter("numberOfPeopleItFeeds")).thenReturn(numberOfPeopleItFeeds);
     when(request.getParameter("typeOfFood")).thenReturn(typeOfFood);
     when(request.getParameter("description")).thenReturn(description);
+    when(request.getParameter("collegeId")).thenReturn(collegeId);
 
     // Run requestToPost() on the Mock HTTP Request.
     Post testPost = new Post();
-    testPost.requestToPost(request, collegeId);
+    testPost.requestToPost(request);
 
     return testPost;
   }


### PR DESCRIPTION
Changes the setup of the Datastore such that all posts are now a "Post" entity kind.

Previously, each post was put under an entity kind of its collegeId. However, this limits the querying ability, and prevents querying all posts. It also limits scalability because each college needs to create an entity kind. Now, each post is put under a "Post" entity kind and has a "collegeId" property. To find posts for a certain college, the query is filtered by the collegeId property. 

Setup before (each college is an entity kind):

- `CollegeId 1`
    - `Post 1`
    - `Post 2`
    - `...`
- `CollegeId 2`
    - `Post 1`
    - `Post 2`
    - `...`
- `CollegeId 3`
    - `Post 1`
    - `Post 2`
    - ` ...`

Setup after (entity kind "College):

- `Post`
    - `CollegeId1` : `Post 1`
    - `CollegeId1` : `Post 2`
    - `CollegeId2` : `Post 1`
    - `...`

Screenshot of the datastore:

![Screenshot 2020-08-31 at 12 20 47 PM](https://user-images.githubusercontent.com/48428336/91758202-74711580-eb84-11ea-844e-7e0ba683ad4f.png)


