### PR TITLE
Add validation to disallow numPeople to be less than 1

### DIFF
--- a/src/main/java/com/google/sps/data/Post.java
+++ b/src/main/java/com/google/sps/data/Post.java
@@ -118,6 +118,7 @@ public class Post {
       endHour < 0 || endHour > 23 ||
       endMinute < 0 || endMinute > 59 ||
       numberOfPeopleItFeeds <= 0 ||
+      numberOfPeopleItFeeds > 10000 ||
       startHour > endHour ||
       (startHour == endHour && startMinute > endMinute)) {
       valid = false;

--- a/src/main/java/com/google/sps/data/Post.java
+++ b/src/main/java/com/google/sps/data/Post.java
@@ -117,7 +117,7 @@ public class Post {
       startMinute < 0 || startMinute > 59 ||
       endHour < 0 || endHour > 23 ||
       endMinute < 0 || endMinute > 59 ||
-      numberOfPeopleItFeeds < 0 ||
+      numberOfPeopleItFeeds <= 0 ||
       startHour > endHour ||
       (startHour == endHour && startMinute > endMinute)) {
       valid = false;

--- a/src/main/webapp/assets/js/feedScript.js
+++ b/src/main/webapp/assets/js/feedScript.js
@@ -931,6 +931,9 @@ function validateModalNumber(invalidIds, errorMessages, formElements) {
   if (!modalNumPeople.value) {
     invalidIds.push('modal-num-people');
     errorMessages.push('number of people the event can feed is blank');
+  } else if (modalNumPeople.value <= 0) {
+    invalidIds.push('modal-num-people');
+    errorMessages.push('number of people the event can feed must be greater than 0');
   }
 }
 
@@ -1250,17 +1253,17 @@ function populatePostModalDateTime() {
   const modalEndMinute = document.getElementById('modal-end-minute');
   const endAmOrPm = document.getElementById('end-am-or-pm');
 
-  modalMonth.value = new Date().getMonth() + 1; // Months are indexed at 0
+  modalMonth.value = new Date().getMonth() + 1; // Months are indexed at 0.
   modalDay.value = new Date().getDate();
 
   const nowHours = parseInt(new Date().getHours());
-  // Turn 0-23 hours values into 1-12 hours
+  // Turn 0-23 hours values into 1-12 hours.
   modalStartHour.value = nowHours > 12 ? nowHours - 12 : (nowHours !== 0 ? nowHours : 12);
   modalStartMinute.value = '00';
   startAmOrPm.value = nowHours >= 12 ? 'pm' : 'am';
 
   const anHourFromNow = (nowHours + 1) % 24;
-  // Turn 0-23 hours values into 1-12 hours
+  // Turn 0-23 hours values into 1-12 hours.
   modalEndHour.value = anHourFromNow > 12 ?
     anHourFromNow - 12 : (anHourFromNow !== 0 ? anHourFromNow : 12);
   modalEndMinute.value = '00';

--- a/src/main/webapp/assets/js/feedScript.js
+++ b/src/main/webapp/assets/js/feedScript.js
@@ -934,6 +934,9 @@ function validateModalNumber(invalidIds, errorMessages, formElements) {
   } else if (modalNumPeople.value <= 0) {
     invalidIds.push('modal-num-people');
     errorMessages.push('number of people the event can feed must be greater than 0');
+  } else if (modalNumPeople.value > 10000) {
+    invalidIds.push('modal-num-people');
+    errorMessages.push('number of people the event can feed cannot be greater than 10000');
   }
 }
 


### PR DESCRIPTION
Tiny PR

## Disallow numPeople to be less than 1
Now, entries with 'number of people the event can feed' of 0 or fewer are not allowed. Resolves #103.
